### PR TITLE
适配max_completion_tokens

### DIFF
--- a/ChatUI/Program.cs
+++ b/ChatUI/Program.cs
@@ -177,7 +177,7 @@ static async IAsyncEnumerable<Output> ProcessCompletion(string server, string to
     request.Content = new StringContent(JsonSerializer.Serialize(new CompletionRequest
     {
         model = model,
-        max_tokens = 1024,
+        max_completion_tokens = 1024,
         prompt = inputText,
         stream = true,
     }), Encoding.UTF8, "application/json");
@@ -259,7 +259,7 @@ static async IAsyncEnumerable<Output> ProcessChatMessages(string server, string 
         stream = true,
         messages = messages.ToArray(),
         model = model,
-        max_tokens = 1024,
+        max_completion_tokens = 1024,
         temperature = 0.9f,
         top_p = 0.9f,
     }), Encoding.UTF8, "application/json");

--- a/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
+++ b/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
@@ -49,8 +49,6 @@
         /// <example>null</example>
         public string[]? stop { get; set; } = null;
 
-        private int? _maxTokens = null;
-
         /// <summary>
         /// 最大生成长度：设置每个模型响应的令牌数量限制。
         /// API 支持最多 MaxTokensPlaceholderDoNotTranslate 个令牌，
@@ -58,24 +56,7 @@
         /// 一个令牌大约是典型英文文本的 4 个字符。
         /// </summary>
         /// <example>512</example>
-        public int? max_tokens
-        {
-            get => _maxTokens;
-            set
-            {
-                _maxTokens = value;
-                max_completion_tokens = value;
-            }
-        }
-        public int? max_completion_tokens
-        {
-            get => _maxTokens;
-            set
-            {
-                _maxTokens = value;
-                max_tokens = value;
-            }
-        }
+        public int? max_tokens { get; set; } = null;
 
         /// <summary>
         /// 频率损失：根据令牌到目前为止在文本中出现的频率，按比例减少重复令牌的几率。

--- a/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
+++ b/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
@@ -56,7 +56,7 @@
         /// 一个令牌大约是典型英文文本的 4 个字符。
         /// </summary>
         /// <example>512</example>
-        public int? max_tokens { get; set; } = null;
+        public int? max_completion_tokens { get; set; } = null;
 
         /// <summary>
         /// 频率损失：根据令牌到目前为止在文本中出现的频率，按比例减少重复令牌的几率。

--- a/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
+++ b/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
@@ -49,6 +49,8 @@
         /// <example>null</example>
         public string[]? stop { get; set; } = null;
 
+        private int? _maxTokens = null;
+
         /// <summary>
         /// 最大生成长度：设置每个模型响应的令牌数量限制。
         /// API 支持最多 MaxTokensPlaceholderDoNotTranslate 个令牌，
@@ -56,7 +58,24 @@
         /// 一个令牌大约是典型英文文本的 4 个字符。
         /// </summary>
         /// <example>512</example>
-        public int? max_tokens { get; set; } = null;
+        public int? max_tokens
+        {
+            get => _maxTokens;
+            set
+            {
+                _maxTokens = value;
+                max_completion_tokens = value;
+            }
+        }
+        public int? max_completion_tokens
+        {
+            get => _maxTokens;
+            set
+            {
+                _maxTokens = value;
+                max_tokens = value;
+            }
+        }
 
         /// <summary>
         /// 频率损失：根据令牌到目前为止在文本中出现的频率，按比例减少重复令牌的几率。

--- a/src/LLamaWorker.http
+++ b/src/LLamaWorker.http
@@ -57,7 +57,7 @@ Content-Type: application/json
   "model": "default",
   "stream": true,
   "prompt": "You are a helpful assistant.Say this is a test.",
-  "max_tokens": 100
+  "max_completion_tokens": 100
 }
 
 ###

--- a/src/Middleware/TypeConversionMiddleware.cs
+++ b/src/Middleware/TypeConversionMiddleware.cs
@@ -57,6 +57,14 @@ namespace LLamaWorker.Middleware
                                     );
                                 }
 
+                                // 适配 max_tokens
+                                if (data.TryGetValue("max_tokens", out var max_tokens) && max_tokens.ValueKind == JsonValueKind.Number)
+                                {
+                                    data["max_completion_tokens"] = JsonSerializer.Deserialize<JsonElement>(
+                                        JsonSerializer.Serialize(max_tokens.GetInt32())
+                                    );
+                                }
+
                                 var newBody = JsonSerializer.Serialize(data);
                                 context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(newBody));
                             }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -5,6 +5,7 @@ using LLamaWorker.Middleware;
 using LLamaWorker.Services;
 using Microsoft.OpenApi.Models;
 using System.Reflection;
+using System.Text;
 
 namespace LLamaWorker
 {
@@ -14,7 +15,7 @@ namespace LLamaWorker
         {
             var builder = WebApplication.CreateBuilder(args);
 
-
+            Console.OutputEncoding = Encoding.UTF8;
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();

--- a/src/Services/LLmModelService.cs
+++ b/src/Services/LLmModelService.cs
@@ -213,7 +213,7 @@ namespace LLamaWorker.Services
                     new ChatCompletionResponseChoice
                     {
                         index = 0,
-                        finish_reason = completion_tokens >= request.max_tokens ? "length" : "stop",
+                        finish_reason = completion_tokens >= request.max_completion_tokens ? "length" : "stop",
                         message = new ChatCompletionMessage
                         {
                             role = "assistant",
@@ -716,7 +716,7 @@ namespace LLamaWorker.Services
 
             InferenceParams inferenceParams = new InferenceParams()
             {
-                MaxTokens = request.max_tokens.HasValue && request.max_tokens.Value > 0 ? request.max_tokens.Value : -1,
+                MaxTokens = request.max_completion_tokens.HasValue && request.max_completion_tokens.Value > 0 ? request.max_completion_tokens.Value : -1,
                 AntiPrompts = stop,
                 SamplingPipeline = request.seed.HasValue ? new DefaultSamplingPipeline
                 {


### PR DESCRIPTION
This pull request includes several changes to standardize the use of `max_completion_tokens` instead of `max_tokens` across the codebase. The key changes involve updating variable names, adapting middleware logic, and ensuring consistent token handling in various components.

Changes to variable names:

* [`ChatUI/Program.cs`](diffhunk://#diff-46b9bb446644483f703e49960e0c20acb1a7c8d9d2408abdd864ac5eaaa14569L180-R180): Updated `max_tokens` to `max_completion_tokens` in `ProcessCompletion` and `ProcessChatMessages` methods. [[1]](diffhunk://#diff-46b9bb446644483f703e49960e0c20acb1a7c8d9d2408abdd864ac5eaaa14569L180-R180) [[2]](diffhunk://#diff-46b9bb446644483f703e49960e0c20acb1a7c8d9d2408abdd864ac5eaaa14569L262-R262)
* [`LLamaWorker.OpenAIModels/BaseCompletionModels.cs`](diffhunk://#diff-a5f619626a6b26409c2922bf9110a5e6eb8c07b3d94953985123caaed5b0ac68L59-R59): Changed the `max_tokens` property to `max_completion_tokens` in the `BaseCompletionRequest` class.
* [`src/LLamaWorker.http`](diffhunk://#diff-c3c334c8550110a4c7e0d0a5fd9a1b1bab6d7b0f48bc9eb36f25f8d60f8702acL60-R60): Replaced `max_tokens` with `max_completion_tokens` in the JSON content.

Middleware adaptation:

* [`src/Middleware/TypeConversionMiddleware.cs`](diffhunk://#diff-88d79bcb167816eeab712157ae140a62eef20a795b51e719eed2c277892bfa88R60-R67): Added logic to adapt `max_tokens` to `max_completion_tokens` if present in the request data.

Other changes:

* [`src/Program.cs`](diffhunk://#diff-4a4588302b6b6704e8d835eeae2bc4e72d329487921efe11aa2c30c4ee345e3fL17-R18): Set the console output encoding to UTF-8.
* [`src/Services/LLmModelService.cs`](diffhunk://#diff-cf062b8d576961aed9de5af52a3e3e663fce35d37eefd9040c683ab4971f0f7cL216-R216): Updated references from `max_tokens` to `max_completion_tokens` in the `CreateChatCompletionAsync` and `GetInferenceParams` methods. [[1]](diffhunk://#diff-cf062b8d576961aed9de5af52a3e3e663fce35d37eefd9040c683ab4971f0f7cL216-R216) [[2]](diffhunk://#diff-cf062b8d576961aed9de5af52a3e3e663fce35d37eefd9040c683ab4971f0f7cL719-R719)