### PR TITLE
Thinking switch

### DIFF
--- a/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
+++ b/LLamaWorker.OpenAIModels/BaseCompletionModels.cs
@@ -81,6 +81,11 @@
         /// 用户：最终用户的唯一标识符
         /// </summary>
         public string? user { get; set; }
+
+        /// <summary>
+        /// 针对所有支持深度思考的模型，默认开启深度思考
+        /// </summary>
+        public bool enable_thinking { get; set; } = true;
     }
 
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ English | [中文](README_CN.md)
 - **OpenAI API Compatible**: Offers an API similar to OpenAI's / Azure OpenAI, making migration and integration easy.
 - **Multi-Model Support**: Supports configuring and switching between different models to meet the needs of various scenarios.
 - **Streaming Response**: Supports streaming responses to improve the efficiency of processing large responses.
-- **Embedding Support**: Provides text embedding functionality with support for various embedding models.
+- **Embedding Support**: Provides text embedding functionality with support for various embedding models, including Base64 return support.
 - **chat templates**: Provides some common chat templates.
 - **Auto-Release**: Supports automatic release of loaded models.
 - **Function Call**: Supports function calls.
+- **Deep Thinking Switch**: Provides API parameters for flexible switching of deep thinking modes.
 - **API Key Authentication**: Supports API Key authentication.
 - **Test UI**: Provides a friendly development test UI.
 - **Gradio UI Demo**: Provides a UI demo based on Gradio.NET.
@@ -151,6 +152,25 @@ LLamaWorker offers the following API endpoints:
 - `/models/info`: Returns basic information about the model
 - `/models/config`: Returns information about configured models
 - `/models/{modelId}/switch`: Switch to a specified model
+
+## Deep Thinking Switch
+
+Provides API parameters for flexible switching of deep thinking modes.
+
+Add the `enable_thinking` parameter in the request, which defaults to `true`. For models that support deep thinking, set it to `false` to turn off the deep thinking mode.
+
+```json
+{
+  "model": "Qwen3-8B",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Where is the temperature high between Beijing and Shanghai?"
+    }
+  ],
+  "enable_thinking": false,
+}
+```
 
 ## Gradio UI Demo
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,10 +11,11 @@ LLamaWorker 是一个基于 [LLamaSharp](https://github.com/SciSharp/LLamaSharp?
 - **兼容 OpenAI API**: 提供与 OpenAI / Azure OpenAI 类似的 API，方便迁移和集成。
 - **多模型支持**: 支持配置和切换不同的模型，满足不同场景的需求。
 - **流式响应**: 支持流式响应，提高大型响应的处理效率。
-- **嵌入支持**: 提供文本嵌入功能，支持多种嵌入模型。
+- **嵌入支持**: 提供文本嵌入功能，支持多种嵌入模型，并提供 Base64 返回支持。
 - **对话模版**: 提供了一些常见的对话模版。
 - **自动释放**: 支持自动释放已加载模型。
 - **函数调用**: 支持函数调用。
+- **深度思考切换**: 提供 API 参数灵活切换深度思考模式。
 - **API Key 认证**: 支持 API Key 认证。
 - **测试 UI**: 提供了一个友好的开发测试 UI。
 - **Gradio UI Demo**: 提供了一个基于 Gradio.NET 的 UI 演示。
@@ -152,6 +153,25 @@ LLamaWorker 提供以下 API 端点：
 - `/models/info`: 返回模型的基本信息
 - `/models/config`: 返回已配置的模型信息
 - `/models/{modelId}/switch`: 切换到指定模型
+
+## 深度思考切换
+
+提供 API 参数灵活切换深度思考模式。
+
+在请求中添加 `enable_thinking` 参数，默认为 `true` ，针对支持深度思考的模型，设置为 `false`，即可关闭深度思考模式。
+
+```json
+{
+  "model": "Qwen3-8B",
+  "messages": [
+    {
+      "role": "user",
+      "content": "北京和上海哪里气温高？"
+    }
+  ],
+  "enable_thinking": false,
+}
+```
 
 ## Gradio UI Demo
 

--- a/src/Services/LLmModelService.cs
+++ b/src/Services/LLmModelService.cs
@@ -532,13 +532,13 @@ namespace LLamaWorker.Services
                     var historyTransform = Activator.CreateInstance(type) as ITemplateTransform;
                     if (historyTransform != null)
                     {
-                        history = historyTransform.HistoryToText(messages, _toolPromptGenerator, _usedset.ToolPrompt, toolPrompt);
+                        history = historyTransform.HistoryToText(messages, _toolPromptGenerator, _usedset.ToolPrompt, toolPrompt, request.enable_thinking);
                     }
                 }
             }
             else
             {
-                history = new BaseHistoryTransform().HistoryToText(messages, _toolPromptGenerator, _usedset.ToolPrompt, toolPrompt);
+                history = new BaseHistoryTransform().HistoryToText(messages, _toolPromptGenerator, _usedset.ToolPrompt, toolPrompt, request.enable_thinking);
             }
 
             return new ChatHistoryResult(history, toolenabled, toolstopwords);

--- a/src/Transform/BaseTransform.cs
+++ b/src/Transform/BaseTransform.cs
@@ -31,6 +31,11 @@ namespace LLamaWorker.Transform
         protected virtual string thinkToken => "";
 
         /// <summary>
+        /// 跳过思考标记
+        /// </summary>
+        protected virtual string stopThinking => "";
+
+        /// <summary>
         /// 系统标记
         /// </summary>
         protected virtual string systemToken => "<|im_start|>system";
@@ -58,8 +63,9 @@ namespace LLamaWorker.Transform
         /// <param name="generator"></param>
         /// <param name="toolinfo"></param>
         /// <param name="toolPrompt"></param>
+        /// <param name="thinking"></param>
         /// <returns></returns>
-        public virtual string HistoryToText(ChatCompletionMessage[] history, ToolPromptGenerator generator, ToolPromptInfo toolinfo, string toolPrompt = "")
+        public virtual string HistoryToText(ChatCompletionMessage[] history, ToolPromptGenerator generator, ToolPromptInfo toolinfo, string toolPrompt = "", bool thinking = true)
         {
 
             // 若有系统消息，则会放在最开始
@@ -190,10 +196,16 @@ namespace LLamaWorker.Transform
                 sb.Append(assistantToken + "\n");
             }
 
-            if (promptTrim)
+            if (promptTrim && thinking)
             {
                 // 去除开头末尾的换行符和空格
                 return sb.ToString().Trim();
+            }
+
+            if (!thinking)
+            {
+                // 跳过思考过程
+                sb.Append(stopThinking);
             }
 
             //Console.WriteLine(sb.ToString());

--- a/src/Transform/BaseTransform.cs
+++ b/src/Transform/BaseTransform.cs
@@ -196,20 +196,22 @@ namespace LLamaWorker.Transform
                 sb.Append(assistantToken + "\n");
             }
 
-            if (promptTrim && thinking)
+            var historyText = sb.ToString();
+
+            if (promptTrim)
             {
                 // 去除开头末尾的换行符和空格
-                return sb.ToString().Trim();
+                historyText = historyText.Trim();
             }
 
             if (!thinking)
             {
                 // 跳过思考过程
-                sb.Append(stopThinking);
+                historyText += stopThinking;
             }
 
             //Console.WriteLine(sb.ToString());
-            return sb.ToString();
+            return historyText;
         }
 
     }

--- a/src/Transform/DeepSeekTransform.cs
+++ b/src/Transform/DeepSeekTransform.cs
@@ -24,6 +24,9 @@
         protected override string thinkToken => "</think>";
 
         /// <inheritdoc/>
+        protected override string stopThinking => "\n<think>\n\n</think>\n\n";
+
+        /// <inheritdoc/>
         protected override bool promptTrim => true;
     }
 

--- a/src/Transform/ITemplateTransform.cs
+++ b/src/Transform/ITemplateTransform.cs
@@ -6,6 +6,6 @@ namespace LLamaWorker.Transform
 {
     public interface ITemplateTransform
     {
-        public string HistoryToText(ChatCompletionMessage[] history, ToolPromptGenerator generator, ToolPromptInfo toolinfo, string toolPrompt);
+        public string HistoryToText(ChatCompletionMessage[] history, ToolPromptGenerator generator, ToolPromptInfo toolinfo, string toolPrompt, bool thinking);
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature called "Deep Thinking Mode" and includes updates to support its implementation across the codebase. Key changes include adding a new `enable_thinking` parameter, modifying history transformation logic, and updating documentation to reflect the new feature.

### Feature Implementation: Deep Thinking Mode
* [`LLamaWorker.OpenAIModels/BaseCompletionModels.cs`](diffhunk://#diff-a5f619626a6b26409c2922bf9110a5e6eb8c07b3d94953985123caaed5b0ac68R84-R88): Added a new `enable_thinking` property to the `BaseCompletionRequest` class, defaulting to `true`. This allows users to toggle deep thinking mode.
* [`src/Transform/BaseTransform.cs`](diffhunk://#diff-1c3f8ace2098413ec9761bcd1479046298eedd87ff93f66d0dd54f23f4c8cf27R66-R68): Updated the `HistoryToText` method to accept a `thinking` parameter, which determines whether to include deep thinking steps in the generated history. Added `stopThinking` logic to append a marker when deep thinking is disabled. [[1]](diffhunk://#diff-1c3f8ace2098413ec9761bcd1479046298eedd87ff93f66d0dd54f23f4c8cf27R66-R68) [[2]](diffhunk://#diff-1c3f8ace2098413ec9761bcd1479046298eedd87ff93f66d0dd54f23f4c8cf27L170-R214)
* [`src/Transform/DeepSeekTransform.cs`](diffhunk://#diff-ca33661ba6b1696426520b8553b5e60b35d1dfb76916ae62cb97d8c2b927e56cR26-R28): Overrode `stopThinking` in the `DeepSeekTransform` class to provide specific markers for deep thinking mode.
* [`src/Transform/ITemplateTransform.cs`](diffhunk://#diff-cecc8c9f172db8acd239b1b7ae99c59e8f5deead7110d9275ce38bf8f14486e6L9-R9): Updated the `ITemplateTransform` interface to include the `thinking` parameter in the `HistoryToText` method signature.

### Integration with Services
* [`src/Services/LLmModelService.cs`](diffhunk://#diff-cf062b8d576961aed9de5af52a3e3e663fce35d37eefd9040c683ab4971f0f7cL535-R541): Updated the `GetChatHistory` method to pass the `enable_thinking` property from the request to the history transformation logic.

### Documentation Updates
* `README.md` and `README_CN.md`: Updated feature lists to include the new "Deep Thinking Switch" functionality. Added examples and explanations of how to use the `enable_thinking` parameter in API requests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156-R174) [[3]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L14-R18) [[4]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R157-R175)

These changes collectively enable flexible control over deep thinking processes in the application while ensuring proper integration and clear user guidance.